### PR TITLE
use string for param due to ARC bug 3969

### DIFF
--- a/runTimeEnvironments/APPS-LDMX-SIMPROD-3.0
+++ b/runTimeEnvironments/APPS-LDMX-SIMPROD-3.0
@@ -1,6 +1,6 @@
 # description: LDMX Production Simulation wrapper for aCT/Rucio
 # param:LDMX_STORAGE_BASE:string::local path to persistent storage base for LDMX data
-# param:KEEP_LOCAL_COPY:int::set to non-zero (suggest: 1) to keep a local copy of LDMX data (in local persistent storage)
+# param:KEEP_LOCAL_COPY:string::set to non-zero (suggest: 1) to keep a local copy of LDMX data (in local persistent storage)
 
 if [ "x$1" = "x0" ]; then
   if [ -z "$LDMX_STORAGE_BASE" ]; then


### PR DESCRIPTION
Setting an int parameter doesn't work in ARC. Reported in https://bugzilla.nordugrid.org/show_bug.cgi?id=3969