### PR TITLE
Example configs for 8 GeV muon production

### DIFF
--- a/exampleConfigs/8GeV_ecalGammaMuMu.py
+++ b/exampleConfigs/8GeV_ecalGammaMuMu.py
@@ -1,0 +1,137 @@
+import os
+import sys
+import json
+
+from LDMX.Framework import ldmxcfg
+from LDMX.Biasing import ecal
+from LDMX.SimCore import generators as gen
+from LDMX.Biasing import filters
+from LDMX.SimCore import bias_operators
+from LDMX.Biasing import include as includeBiasing
+from LDMX.Biasing import util
+
+# We need to create a process
+thisPassName = 'sim'
+p = ldmxcfg.Process(thisPassName)
+
+
+# We import the Ecal PN template for 8 GeV beam
+detector = 'ldmx-det-v14-8gev'
+sim = ecal.gamma_mumu(detector, gen.single_8gev_e_upstream_tagger())
+sim.description = '8 GeV ecal muon conversion simulation'
+
+sim.biasing_operators = [bias_operators.GammaToMuPair('ecal', 3.E4, 5000.)]
+
+includeBiasing.library()
+sim.actions.clear()
+sim.actions.extend([
+   filters.TaggerVetoFilter(thresh = 7600.),
+   # Only consider events where a hard brem occurs
+   filters.TargetBremFilter(recoil_max_p = 3000.,brem_min_e = 5000.),
+   # Only consider events where a PN reaction happens in the ECal
+   filters.EcalProcessFilter(process='GammaToMuPair'),
+   # Tag all photo-nuclear tracks to persist them to the event
+   util.TrackProcessFilter.gamma_mumu()
+
+   ])
+
+p.run = int(sys.argv[1])
+nElectrons = 1
+beamEnergy = 8.0; #in GeV
+
+p.maxEvents = 10000          #min of 10000 (from LK)
+p.maxTriesPerEvent = 10000000
+#p.maxTriesPerEvent = 1000
+
+#p.histogramFile = f'hist.root'
+#p.outputFiles = [sys.argv[2]]
+
+import LDMX.Ecal.EcalGeometry
+import LDMX.Ecal.ecal_hardcoded_conditions
+import LDMX.Hcal.HcalGeometry
+import LDMX.Hcal.hcal_hardcoded_conditions
+
+from LDMX.Ecal import digi as eDigi
+from LDMX.Ecal import vetos
+from LDMX.Hcal import digi as hDigi
+from LDMX.Hcal import hcal
+
+from LDMX.TrigScint.trigScint import TrigScintDigiProducer
+from LDMX.TrigScint.trigScint import TrigScintClusterProducer
+from LDMX.TrigScint.trigScint import trigScintTrack
+
+from LDMX.Recon.electronCounter import ElectronCounter
+from LDMX.Recon.simpleTrigger import TriggerProcessor
+
+tsDigisDown = TrigScintDigiProducer.pad1()
+tsDigisTag = TrigScintDigiProducer.pad2()
+tsDigisUp = TrigScintDigiProducer.pad3()
+tsDigisDown.randomSeed = 1
+tsDigisTag.randomSeed = 1
+tsDigisUp.randomSeed = 1
+
+if "v12" in detector :
+   tsDigisTag.input_collection="TriggerPadTagSimHits"
+   tsDigisUp.input_collection="TriggerPadUpSimHits"
+   tsDigisDown.input_collection="TriggerPadDnsSimHits"
+
+tsClustersDown = TrigScintClusterProducer.pad1()
+tsClustersTag = TrigScintClusterProducer.pad2()
+tsClustersUp = TrigScintClusterProducer.pad3()
+
+tsClustersDown.input_collection = tsDigisDown.output_collection
+tsClustersTag.input_collection = tsDigisTag.output_collection
+tsClustersUp.input_collection = tsDigisUp.output_collection
+
+tsClustersTag.input_pass_name = thisPassName
+tsClustersUp.input_pass_name = tsClustersTag.input_pass_name
+tsClustersDown.input_pass_name = tsClustersTag.input_pass_name
+
+trigScintTrack.input_pass_name = thisPassName
+trigScintTrack.seeding_collection = tsClustersTag.output_collection
+
+
+#calorimeters
+ecalDigi = eDigi.EcalDigiProducer('ecalDigi')
+ecalReco = eDigi.EcalRecProducer('ecalRecon')
+ecalVeto = vetos.EcalVetoProcessor('ecalVetoBDT')
+hcalDigi = hDigi.HcalDigiProducer('hcalDigi')
+hcalReco = hDigi.HcalRecProducer('hcalRecon')
+hcalVeto = hcal.HcalVetoProcessor('hcalVeto')
+
+
+# electron counter so simpletrigger doesn't crash
+eCount = ElectronCounter(1, "ElectronCounter") # first argument is number of electrons in simulation
+eCount.use_simulated_electron_number = True
+eCount.input_pass_name=thisPassName
+
+simpleTrigger = TriggerProcessor('simpleTrigger')
+simpleTrigger.start_layer = 0
+simpleTrigger.input_pass = thisPassName
+
+p.sequence=[sim,
+            ecalDigi,
+            ecalReco,
+            ecalVeto,
+            tsDigisTag,
+            tsDigisUp,
+            tsDigisDown,
+            tsClustersTag,
+            tsClustersUp,
+            tsClustersDown,
+            trigScintTrack,
+            eCount,
+            #simpleTrigger, 
+            hcalDigi, 
+            hcalReco, 
+            hcalVeto]
+
+p.keep = ["drop MagnetScoringPlaneHits", "drop TrackerScoringPlaneHits", "drop HcalScoringPlaneHits"]
+p.outputFiles=[sys.argv[2]]
+
+p.termLogLevel = 2
+logEvents = 20
+if (p.maxEvents < logEvents):
+   logEvents = p.maxEvents
+
+p.logFrequency = int(p.maxEvents/logEvents)

--- a/exampleConfigs/8GeV_ecalGammaMuMu.py
+++ b/exampleConfigs/8GeV_ecalGammaMuMu.py
@@ -105,7 +105,7 @@ eCount = ElectronCounter(1, "ElectronCounter") # first argument is number of ele
 eCount.use_simulated_electron_number = True
 eCount.input_pass_name=thisPassName
 
-simpleTrigger = TriggerProcessor('simpleTrigger')
+simpleTrigger = TriggerProcessor('simpleTrigger', 8000.)
 simpleTrigger.start_layer = 0
 simpleTrigger.input_pass = thisPassName
 

--- a/exampleConfigs/8GeV_targetGammaMuMu.py
+++ b/exampleConfigs/8GeV_targetGammaMuMu.py
@@ -1,0 +1,136 @@
+import os
+import sys
+import json
+
+from LDMX.Framework import ldmxcfg
+from LDMX.Biasing import target
+from LDMX.SimCore import generators as gen
+from LDMX.Biasing import filters
+from LDMX.SimCore import bias_operators
+from LDMX.Biasing import include as includeBiasing
+from LDMX.Biasing import util
+
+# We need to create a process
+thisPassName = 'sim'
+p = ldmxcfg.Process(thisPassName)
+
+
+# We import the Ecal PN template for 8 GeV beam
+detector = 'ldmx-det-v14-8gev'
+sim = target.gamma_mumu(detector, gen.single_8gev_e_upstream_tagger())
+sim.description = '8 GeV target muon conversion simulation'
+
+sim.biasing_operators = [bias_operators.GammaToMuPair('target', 1.E6, 5000.)]
+
+includeBiasing.library()
+sim.actions.clear()
+sim.actions.extend([
+   filters.TaggerVetoFilter(thresh = 7600.),
+   # Only consider events where a hard brem occurs
+   filters.TargetBremFilter(recoil_max_p = 3000.,brem_min_e = 5000.),
+   # Only consider events where a PN reaction happens in the ECal
+   filters.TargetGammaMuMuFilter(),
+   # Tag all photo-nuclear tracks to persist them to the event
+   util.TrackProcessFilter.gamma_mumu()
+
+   ])
+
+p.run = int(sys.argv[1])
+nElectrons = 1
+beamEnergy = 8.0; #in GeV
+
+p.maxEvents = 10000          #min of 10000 (from LK)
+p.maxTriesPerEvent = 10000
+
+#p.histogramFile = f'hist.root'
+#p.outputFiles = [sys.argv[2]]
+
+import LDMX.Ecal.EcalGeometry
+import LDMX.Ecal.ecal_hardcoded_conditions
+import LDMX.Hcal.HcalGeometry
+import LDMX.Hcal.hcal_hardcoded_conditions
+
+from LDMX.Ecal import digi as eDigi
+from LDMX.Ecal import vetos
+from LDMX.Hcal import digi as hDigi
+from LDMX.Hcal import hcal
+
+from LDMX.TrigScint.trigScint import TrigScintDigiProducer
+from LDMX.TrigScint.trigScint import TrigScintClusterProducer
+from LDMX.TrigScint.trigScint import trigScintTrack
+
+from LDMX.Recon.electronCounter import ElectronCounter
+from LDMX.Recon.simpleTrigger import TriggerProcessor
+
+tsDigisDown = TrigScintDigiProducer.pad1()
+tsDigisTag = TrigScintDigiProducer.pad2()
+tsDigisUp = TrigScintDigiProducer.pad3()
+tsDigisDown.randomSeed = 1
+tsDigisTag.randomSeed = 1
+tsDigisUp.randomSeed = 1
+
+if "v12" in detector :
+   tsDigisTag.input_collection="TriggerPadTagSimHits"
+   tsDigisUp.input_collection="TriggerPadUpSimHits"
+   tsDigisDown.input_collection="TriggerPadDnsSimHits"
+
+tsClustersDown = TrigScintClusterProducer.pad1()
+tsClustersTag = TrigScintClusterProducer.pad2()
+tsClustersUp = TrigScintClusterProducer.pad3()
+
+tsClustersDown.input_collection = tsDigisDown.output_collection
+tsClustersTag.input_collection = tsDigisTag.output_collection
+tsClustersUp.input_collection = tsDigisUp.output_collection
+
+tsClustersTag.input_pass_name = thisPassName
+tsClustersUp.input_pass_name = tsClustersTag.input_pass_name
+tsClustersDown.input_pass_name = tsClustersTag.input_pass_name
+
+trigScintTrack.input_pass_name = thisPassName
+trigScintTrack.seeding_collection = tsClustersTag.output_collection
+
+
+#calorimeters
+ecalDigi = eDigi.EcalDigiProducer('ecalDigi')
+ecalReco = eDigi.EcalRecProducer('ecalRecon')
+ecalVeto = vetos.EcalVetoProcessor('ecalVetoBDT')
+hcalDigi = hDigi.HcalDigiProducer('hcalDigi')
+hcalReco = hDigi.HcalRecProducer('hcalRecon')
+hcalVeto = hcal.HcalVetoProcessor('hcalVeto')
+
+
+# electron counter so simpletrigger doesn't crash
+eCount = ElectronCounter(1, "ElectronCounter") # first argument is number of electrons in simulation
+eCount.use_simulated_electron_number = True
+eCount.input_pass_name=thisPassName
+
+simpleTrigger = TriggerProcessor('simpleTrigger')
+simpleTrigger.start_layer = 0
+simpleTrigger.input_pass = thisPassName
+
+p.sequence=[sim,
+            ecalDigi,
+            ecalReco,
+            ecalVeto,
+            tsDigisTag,
+            tsDigisUp,
+            tsDigisDown,
+            tsClustersTag,
+            tsClustersUp,
+            tsClustersDown,
+            trigScintTrack,
+            eCount,
+            #simpleTrigger, 
+            hcalDigi, 
+            hcalReco, 
+            hcalVeto]
+
+p.keep = ["drop MagnetScoringPlaneHits", "drop TrackerScoringPlaneHits", "drop HcalScoringPlaneHits"]
+p.outputFiles=[sys.argv[2]]
+
+p.termLogLevel = 2
+logEvents = 20
+if (p.maxEvents < logEvents):
+   logEvents = p.maxEvents
+
+p.logFrequency = int(p.maxEvents/logEvents)

--- a/exampleConfigs/8GeV_targetGammaMuMu.py
+++ b/exampleConfigs/8GeV_targetGammaMuMu.py
@@ -104,7 +104,7 @@ eCount = ElectronCounter(1, "ElectronCounter") # first argument is number of ele
 eCount.use_simulated_electron_number = True
 eCount.input_pass_name=thisPassName
 
-simpleTrigger = TriggerProcessor('simpleTrigger')
+simpleTrigger = TriggerProcessor('simpleTrigger', 8000.)
 simpleTrigger.start_layer = 0
 simpleTrigger.input_pass = thisPassName
 

--- a/exampleConfigs/8GeV_targetPN.py
+++ b/exampleConfigs/8GeV_targetPN.py
@@ -1,0 +1,136 @@
+#!/bin/python
+
+import os
+import sys
+import json
+
+from LDMX.Framework import ldmxcfg
+
+# set a 'pass name';
+thisPassName="sim"
+p=ldmxcfg.Process(thisPassName)
+
+p.maxTriesPerEvent = 10000
+#import all processors
+
+from LDMX.Biasing import target
+from LDMX.SimCore import generators as gen
+
+detector='ldmx-det-v14-8gev'
+sim = target.photo_nuclear(detector, gen.single_8gev_e_upstream_tagger()) #thresh in target.photo_nuclear needs to be changed to 4850., currently configured for 4 GeV
+sim.beamSpotSmear = [20.,80.,0.]
+sim.description = '8 GeV target PN simulation'
+
+
+############################################################
+# Below should be the same for all sim scenarios
+
+#
+#Set run parameters. These are all pulled from the job config
+#
+
+p.run = int(sys.argv[1])
+nElectrons = 1
+beamEnergy = 8.0; #in GeV
+
+p.maxEvents = 1000
+
+#p.histogramFile = f'hist.root'
+p.outputFiles = [sys.argv[2]]
+
+import LDMX.Ecal.EcalGeometry
+import LDMX.Ecal.ecal_hardcoded_conditions
+import LDMX.Hcal.HcalGeometry
+import LDMX.Hcal.hcal_hardcoded_conditions
+
+from LDMX.Ecal import digi as eDigi
+from LDMX.Ecal import vetos
+from LDMX.Hcal import digi as hDigi
+from LDMX.Hcal import hcal
+
+from LDMX.TrigScint.trigScint import TrigScintDigiProducer
+from LDMX.TrigScint.trigScint import TrigScintClusterProducer
+from LDMX.TrigScint.trigScint import trigScintTrack
+
+from LDMX.Recon.electronCounter import ElectronCounter
+from LDMX.Recon.simpleTrigger import TriggerProcessor
+
+
+#and reco...
+
+#TS digi + clustering + track chain. downstream pad removed to far upstream, but only in v14; left where it was in v12
+tsDigisDown = TrigScintDigiProducer.pad1()
+tsDigisTag = TrigScintDigiProducer.pad2()
+tsDigisUp = TrigScintDigiProducer.pad3()
+tsDigisDown.randomSeed = 1
+tsDigisTag.randomSeed = 1
+tsDigisUp.randomSeed = 1
+
+if "v12" in detector :
+   tsDigisTag.input_collection="TriggerPadTagSimHits"
+   tsDigisUp.input_collection="TriggerPadUpSimHits"
+   tsDigisDown.input_collection="TriggerPadDnsSimHits"
+
+tsClustersDown = TrigScintClusterProducer.pad1()
+tsClustersTag = TrigScintClusterProducer.pad2()
+tsClustersUp = TrigScintClusterProducer.pad3()
+
+tsClustersDown.input_collection = tsDigisDown.output_collection
+tsClustersTag.input_collection = tsDigisTag.output_collection
+tsClustersUp.input_collection = tsDigisUp.output_collection
+
+#make sure to pick up the right pass
+tsClustersTag.input_pass_name = thisPassName
+tsClustersUp.input_pass_name = tsClustersTag.input_pass_name
+tsClustersDown.input_pass_name = tsClustersTag.input_pass_name
+
+trigScintTrack.input_pass_name = thisPassName
+trigScintTrack.seeding_collection = tsClustersTag.output_collection
+
+
+#calorimeters
+ecalDigi = eDigi.EcalDigiProducer('ecalDigi')
+ecalReco = eDigi.EcalRecProducer('ecalRecon')
+ecalVeto = vetos.EcalVetoProcessor('ecalVetoBDT')
+hcalDigi = hDigi.HcalDigiProducer('hcalDigi')
+hcalReco = hDigi.HcalRecProducer('hcalRecon')
+hcalVeto = hcal.HcalVetoProcessor('hcalVeto')
+
+
+# electron counter so simpletrigger doesn't crash
+eCount = ElectronCounter(1, "ElectronCounter") # first argument is number of electrons in simulation
+eCount.use_simulated_electron_number = True
+eCount.input_pass_name=thisPassName
+
+#trigger setup, no skim
+simpleTrigger = TriggerProcessor('simpleTrigger')
+simpleTrigger.start_layer = 0
+simpleTrigger.input_pass = thisPassName
+
+p.sequence=[sim, 
+            ecalDigi, 
+            ecalReco, 
+            ecalVeto, 
+            tsDigisTag, 
+            tsDigisUp, 
+            tsDigisDown, 
+            tsClustersTag, 
+            tsClustersUp, 
+            tsClustersDown, 
+            trigScintTrack, 
+            eCount, 
+            #simpleTrigger, 
+            hcalDigi, 
+            hcalReco, 
+            hcalVeto]
+
+p.keep = ["drop MagnetScoringPlaneHits", "drop TrackerScoringPlaneHits", "drop HcalScoringPlaneHits"]
+p.outputFiles=[sys.argv[2]]
+
+
+p.termLogLevel = 2
+logEvents=20
+if p.maxEvents < logEvents :
+   logEvents = p.maxEvents
+p.logFrequency = int(p.maxEvents/logEvents)
+

--- a/exampleConfigs/8GeV_targetPN.py
+++ b/exampleConfigs/8GeV_targetPN.py
@@ -17,7 +17,7 @@ from LDMX.Biasing import target
 from LDMX.SimCore import generators as gen
 
 detector='ldmx-det-v14-8gev'
-sim = target.photo_nuclear(detector, gen.single_8gev_e_upstream_tagger()) #thresh in target.photo_nuclear needs to be changed to 4850., currently configured for 4 GeV
+sim = target.photo_nuclear(detector, gen.single_8gev_e_upstream_tagger())
 sim.beamSpotSmear = [20.,80.,0.]
 sim.description = '8 GeV target PN simulation'
 
@@ -103,7 +103,7 @@ eCount.use_simulated_electron_number = True
 eCount.input_pass_name=thisPassName
 
 #trigger setup, no skim
-simpleTrigger = TriggerProcessor('simpleTrigger')
+simpleTrigger = TriggerProcessor('simpleTrigger', 8000.)
 simpleTrigger.start_layer = 0
 simpleTrigger.input_pass = thisPassName
 


### PR DESCRIPTION
I am uploading my example configuration files that I used to produce a sample of 8 GeV muon conversion events. I presented validation plots for these samples at two SWAN meetings:
[3/11/24 SWAN meeting](https://indico.fnal.gov/event/63722/contributions/286231/attachments/175859/238734/8gev_target_muon_conversion_validation.pdf) (target muon production)
[2/26/24 SWAN meeting](https://indico.fnal.gov/event/63461/contributions/285244/attachments/175453/238001/ecal_muon_conversion_validation.pdf) (ecal muon conversion)

Still on my to-do list, which I can add to this PR before approval, is to check if the biasing factor on the ecal muon conversion sample is correct. For this, I plan to generate small samples with biasing factors 10 times higher and lower than the value I originally used to see if the distribution is affected.